### PR TITLE
Add memcached_check alarm and alarm cluster

### DIFF
--- a/memcached/meta/collectd.yml
+++ b/memcached/meta/collectd.yml
@@ -1,5 +1,5 @@
 {%- from "memcached/map.jinja" import server with context %}
-{%- if server.enabled %}
+{%- if server.get('enabled', False) %}
 local_plugin:
   memcached:
     template: memcached/files/collectd_memcached.conf

--- a/memcached/meta/heka.yml
+++ b/memcached/meta/heka.yml
@@ -1,0 +1,33 @@
+{%- from "memcached/map.jinja" import server with context %}
+{%- if server.get('enabled', False) %}
+metric_collector:
+  trigger:
+    memcached_check:
+      description: 'memcached cannot be checked'
+      severity: down
+      rules:
+      - metric: memcached_check
+        relational_operator: '=='
+        threshold: 0
+        window: 60
+        periods: 0
+        function: last
+  alarm:
+    memcached_check:
+      alerting: enabled
+      triggers:
+      - memcached_check
+      dimension:
+        service: memcached
+aggregator:
+  alarm_cluster:
+    memcached_check:
+      policy: majority_of_members
+      match:
+        service: memcached
+      group_by: hostname
+      members:
+      - memcached_check
+      dimension:
+        cluster_name: memcached
+{%- endif %}

--- a/metadata/service/support.yml
+++ b/metadata/service/support.yml
@@ -4,7 +4,7 @@ parameters:
       collectd:
         enabled: true
       heka:
-        enabled: false
+        enabled: true
       sensu:
         enabled: false
       sphinx:


### PR DESCRIPTION
This adds an alarm and an alarm cluster to make some basic checks on memcached. The global status panel in the memcached dashboard works with this change:

![memcached-dashboard](https://cloud.githubusercontent.com/assets/76594/20490499/80187d34-b00e-11e6-9f63-51822b851d67.png)