### PR TITLE
Replace 'majority_of_members' policy

### DIFF
--- a/memcached/meta/heka.yml
+++ b/memcached/meta/heka.yml
@@ -18,15 +18,25 @@ metric_collector:
       triggers:
       - memcached_check
       dimension:
-        service: memcached
+        service: memcached-check
 aggregator:
   alarm_cluster:
     memcached_check:
-      policy: majority_of_members
+      policy: availability_of_members
+      alerting: enabled
+      match:
+        service: memcached-check
+      group_by: hostname
+      members:
+      - memcached_check
+      dimension:
+        service: memcached
+        nagios_host: 01-service-clusters
+    memcached:
+      policy: highest_severity
       alerting: enabled_with_notification
       match:
         service: memcached
-      group_by: hostname
       members:
       - memcached_check
       dimension:


### PR DESCRIPTION
This policy is going to be removed and it doesn't fit well for this
service. This change introduces a new service cluster using the
'availability_of_members' policy while the 'highest_severity' policy is
applied for the top cluster.