### PR TITLE
Install collectd packages only when needed

### DIFF
--- a/memcached/map.jinja
+++ b/memcached/map.jinja
@@ -1,6 +1,7 @@
 {% set server = salt['grains.filter_by']({
     'Debian': {
-        'pkgs': ['memcached', 'python-memcache', 'python-pymemcache'],
+        'pkgs': ['memcached', 'python-memcache'],
+        'collectd_pkgs': ['python-pymemcache'],
         'service': 'memcached',
         'config': '/etc/memcached.conf',
         'config_template': 'salt://memcached/files/memcached.conf',

--- a/memcached/server.sls
+++ b/memcached/server.sls
@@ -6,6 +6,12 @@ memcached_packages:
   pkg.installed:
   - names: {{ server.pkgs }}
 
+{%- if pillar.collectd is defined %}
+collectd_packages_for_memcached:
+  pkg.installed:
+  - names: {{ server.collectd_pkgs }}
+{%- endif %}
+
 memcached_config:
   file.managed:
   - name: {{ server.config }}


### PR DESCRIPTION
This change ensures that the python-pymemcache package which is required
by collectd isn't installed if collectd itself isn't defined.